### PR TITLE
Fixed response status reason assertions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,15 +10,15 @@ var FIRST_LINE = /(.*?)\n.*/g,
 
     statusCodeReasons = {
         // ok: 200, // cannot add 'ok' directly since it violates underlying 'ok' property
-        accepted: 202,
-        withoutContent: 204, // @todo add 1223 status code
-        badRequest: 400,
-        unauthorised: 401,
-        unauthorized: 401,
-        forbidden: 403,
-        notFound: 404,
-        notAcceptable: 406,
-        rateLimited: 429
+        accepted: { statusCode: 202, name: 'Accepted' },
+        withoutContent: { statusCode: 204, name: 'No Content' }, // @todo add 1223 status code
+        badRequest: { statusCode: 400, name: 'Bad Request' },
+        unauthorised: { statusCode: 401, name: 'Unauthorised' },
+        unauthorized: { statusCode: 401, name: 'Unauthorized' },
+        forbidden: { statusCode: 403, name: 'Forbidden' },
+        notFound: { statusCode: 404, name: 'Not Found' },
+        notAcceptable: { statusCode: 406, name: 'Acceptable' },
+        rateLimited: { statusCode: 429, name: 'Too Many Requests' }
     };
 
 /**
@@ -121,15 +121,15 @@ module.exports = function (sdk, _) {
                 reason, this._obj.reason());
         });
 
-        _.forOwn(statusCodeReasons, function (statusCode, reason) {
-            Assertion.addProperty(reason, function () {
+        _.forOwn(statusCodeReasons, function (reason, assertionName) {
+            Assertion.addProperty(assertionName, function () {
                 new Assertion(this._obj).to.be.postmanResponse;
                 new Assertion(this._obj).to.have.property('reason');
                 new Assertion(this._obj.reason).to.be.a('function');
                 new Assertion(this._obj).to.have.property('details');
                 new Assertion(this._obj.details).to.be.a('function');
 
-                var wantedReason = String(reason).toUpperCase(),
+                var wantedReason = reason.name.toUpperCase(),
                     actualReason = String(this._obj.reason()).toUpperCase(),
                     actualStatusCode = Number(this._obj.details().code);
 
@@ -137,10 +137,10 @@ module.exports = function (sdk, _) {
                     'expected response to have status reason #{exp} but got #{act}',
                     'expected response to not have status reason #{act}',
                     wantedReason, actualReason);
-                this.assert(actualStatusCode === statusCode,
+                this.assert(actualStatusCode === reason.statusCode,
                     'expected response to have status code #{exp} but got #{act}',
                     'expected response to not have status code #{act}',
-                    statusCode, actualStatusCode);
+                    reason.statusCode, actualStatusCode);
             });
         });
 

--- a/test/unit/response.test.js
+++ b/test/unit/response.test.js
@@ -242,15 +242,19 @@ describe('response assertions', function () {
         it('should be asserted correctly', function () {
             expect(new Response({ code: 200 })).to.be.ok;
             expect(new Response({ code: 202 })).to.be.accepted;
+            expect(new Response({ code: 204 })).to.be.withoutContent;
             expect(new Response({ code: 401 })).to.be.unauthorized;
             expect(new Response({ code: 403 })).to.be.forbidden;
+            expect(new Response({ code: 404 })).to.be.notFound;
         });
 
         it('should handle negated assertions correctly', function () {
             expect(new Response({ code: 200 })).to.not.be.accepted;
             expect(new Response({ code: 202 })).to.not.be.unauthorized;
+            expect(new Response({ code: 204 })).to.not.be.rateLimited;
             expect(new Response({ code: 401 })).to.not.be.forbidden;
             expect(new Response({ code: 403 })).to.not.be.ok;
+            expect(new Response({ code: 400 })).to.not.be.notFound;
         });
 
         it('should handle incorrect assertions correctly', function () {
@@ -261,11 +265,17 @@ describe('response assertions', function () {
                 expect(new Response({ code: 202 })).to.be.unauthorized;
             }).to.throw('expected response to have status reason \'UNAUTHORIZED\' but got \'ACCEPTED\'');
             expect(function () {
+                expect(new Response({ code: 204 })).to.be.rateLimited;
+            }).to.throw('expected response to have status reason \'TOO MANY REQUESTS\' but got \'NO CONTENT\'');
+            expect(function () {
                 expect(new Response({ code: 401 })).to.be.forbidden;
             }).to.throw('expected response to have status reason \'FORBIDDEN\' but got \'UNAUTHORIZED\'');
             expect(function () {
                 expect(new Response({ code: 403 })).to.be.ok;
             }).to.throw('expected response to have status reason \'OK\' but got \'FORBIDDEN\'');
+            expect(function () {
+                expect(new Response({ code: 404 })).to.be.ok;
+            }).to.throw('expected response to have status reason \'OK\' but got \'NOT FOUND\'');
         });
 
         it('should handle negated incorrect assertions correctly', function () {
@@ -281,6 +291,9 @@ describe('response assertions', function () {
             expect(function () {
                 expect(new Response({ code: 403 })).to.not.be.forbidden;
             }).to.throw('expected response to not have status reason \'FORBIDDEN\'');
+            expect(function () {
+                expect(new Response({ code: 404 })).to.not.be.notFound;
+            }).to.throw('expected response to not have status reason \'NOT FOUND\'');
         });
     });
 


### PR DESCRIPTION
Discovered by @charliebillen in https://github.com/postmanlabs/postman-app-support/issues/4348

Essentially, assertions of the form:
```js
pm.response.to.be.notFound
```

would end up comparing `NOTFOUND`(from the status code assertion reference) to `NOT FOUND` (from response status reason in the collection SDK).