### PR TITLE
Add support for JSON schema assertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Chai Postman Changelog
 
+#### v1.1.0 (Unreleased)
+* Added support for JSON schema assertions
+* Updated dependencies :arrow_up:
+
 #### v1.0.5 (September 21, 2018)
 * Updated dependencies :arrow_up:
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -383,7 +383,7 @@ module.exports = function (sdk, _, Ajv) {
 
             var ajv,
                 valid,
-                data;
+                data = this._obj;
 
             options = Object.assign({
                 _parseJSON: true, // auto parse JSON by default
@@ -391,18 +391,17 @@ module.exports = function (sdk, _, Ajv) {
             }, options);
 
             // auto parse JSON if `json` or `toJSON` methods exists
-            if (options._parseJSON && this._obj) {
-                if (typeof this._obj.json === 'function') {
-                    data = this._obj.json();
+            if (options._parseJSON && data) {
+                if (typeof data.json === 'function') {
+                    data = data.json();
                 }
-                else if (typeof this._obj.toJSON === 'function') {
-                    data = this._obj.toJSON();
+                else if (typeof data.toJSON === 'function') {
+                    data = data.toJSON();
                 }
-                // remove unknown AJV option `_parseJSON`
-                delete options._parseJSON;
             }
 
-            !data && (data = this._obj);
+            // remove unknown AJV option `_parseJSON`
+            delete options._parseJSON;
 
             ajv = new Ajv(options);
             valid = ajv.validate(schema, data);

--- a/lib/index.js
+++ b/lib/index.js
@@ -26,9 +26,10 @@ var FIRST_LINE = /(.*?)\n.*/g,
  *
  * @param {Object} sdk - The collection sdk library instance.
  * @param {Object} _ - An instance of Lodash, passed from the Sandbox.
+ * @param {Function} Ajv - An instance of Ajv, passed from the Sandbox.
  * @returns {Function} - A chai assertion extension method that references the sdk in a closure.
  */
-module.exports = function (sdk, _) {
+module.exports = function (sdk, _, Ajv) {
     var requestOrResponse = function (what) {
         return sdk.Request.isRequest(what) && 'request' || sdk.Response.isResponse(what) && 'response' || undefined;
     };
@@ -375,6 +376,41 @@ module.exports = function (sdk, _) {
 
             chai.util.flag(this, 'number', total);
             this._obj = total; // @todo: do this the right way adhering to chai standards
+        });
+
+        Assertion.addMethod('jsonSchema', function (schema, options) {
+            new Assertion(schema).to.be.an('object');
+
+            var ajv,
+                valid,
+                data;
+
+            options = Object.assign({
+                _parseJSON: true, // auto parse JSON by default
+                allErrors: true // check all rules collecting all errors
+            }, options);
+
+            // auto parse JSON if `json` or `toJSON` methods exists
+            if (options._parseJSON && this._obj) {
+                if (typeof this._obj.json === 'function') {
+                    data = this._obj.json();
+                }
+                else if (typeof this._obj.toJSON === 'function') {
+                    data = this._obj.toJSON();
+                }
+                // remove unknown AJV option `_parseJSON`
+                delete options._parseJSON;
+            }
+
+            !data && (data = this._obj);
+
+            ajv = new Ajv(options);
+            valid = ajv.validate(schema, data);
+
+            this.assert(valid && !ajv.errors,
+                'expected json to be valid against the specified schema but found following errors: \n' +
+                    ajv.errorsText(),
+                'expected json to be invalid against the specified schema', true, valid);
         });
 
         // @todo add tests for:

--- a/lib/index.js
+++ b/lib/index.js
@@ -386,21 +386,16 @@ module.exports = function (sdk, _, Ajv) {
                 data;
 
             options = Object.assign({
-                _parseJSON: true, // auto parse JSON by default
                 allErrors: true // check all rules collecting all errors
             }, options);
 
-            // auto parse JSON if `json` methods exists
-            // this helps to chain with: pm.response.to.
-            if (options._parseJSON && this._obj && typeof this._obj.json === 'function') {
+            if (sdk.Response.isResponse(this._obj) || sdk.Request.isRequest(this._obj) &&
+                typeof this._obj.json === 'function') {
                 data = this._obj.json();
             }
             else {
                 data = this._obj;
             }
-
-            // remove unknown AJV option `_parseJSON`
-            delete options._parseJSON;
 
             ajv = new Ajv(options);
             valid = ajv.validate(schema, data);

--- a/lib/index.js
+++ b/lib/index.js
@@ -383,21 +383,20 @@ module.exports = function (sdk, _, Ajv) {
 
             var ajv,
                 valid,
-                data = this._obj;
+                data;
 
             options = Object.assign({
                 _parseJSON: true, // auto parse JSON by default
                 allErrors: true // check all rules collecting all errors
             }, options);
 
-            // auto parse JSON if `json` or `toJSON` methods exists
-            if (options._parseJSON && data) {
-                if (typeof data.json === 'function') {
-                    data = data.json();
-                }
-                else if (typeof data.toJSON === 'function') {
-                    data = data.toJSON();
-                }
+            // auto parse JSON if `json` methods exists
+            // this helps to chain with: pm.response.to.
+            if (options._parseJSON && this._obj && typeof this._obj.json === 'function') {
+                data = this._obj.json();
+            }
+            else {
+                data = this._obj;
             }
 
             // remove unknown AJV option `_parseJSON`
@@ -407,9 +406,9 @@ module.exports = function (sdk, _, Ajv) {
             valid = ajv.validate(schema, data);
 
             this.assert(valid && !ajv.errors,
-                'expected json to be valid against the specified schema but found following errors: \n' +
+                'expected data to satisfy schema but found following errors: \n' +
                     ajv.errorsText(),
-                'expected json to be invalid against the specified schema', true, valid);
+                'expected data to not satisfy schema', true, valid);
         });
 
         // @todo add tests for:

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "author": "Postman Labs <help@getpostman.com> (=)",
   "license": "Apache-2.0",
   "devDependencies": {
+    "ajv": "6.6.2",
     "async": "2.6.1",
     "browserify": "16.2.3",
     "chai": "4.2.0",

--- a/test/unit/response.test.js
+++ b/test/unit/response.test.js
@@ -870,18 +870,10 @@ describe('response assertions', function () {
             );
         });
 
-        it('should auto parse JSON by default if .json() method exists', function () {
+        it('should auto parse JSON for PostmanResponse & PostmanRequest instance', function () {
             var response = new Response({ body: '{"alpha": false}' });
 
             expect(response).to.have.jsonSchema(schema);
-        });
-
-        it('should not auto parse JSON if _parseJSON option is false', function () {
-            var response = new Response({ body: '{"alpha": false}' });
-
-            expect(function () {
-                expect(response).to.have.jsonSchema(schema, {_parseJSON: false});
-            }).to.throw('expected data to satisfy schema but found following errors');
         });
     });
 });

--- a/test/unit/response.test.js
+++ b/test/unit/response.test.js
@@ -847,7 +847,7 @@ describe('response assertions', function () {
         it('should handle incorrect assertions correctly', function () {
             expect(function () {
                 expect({random: 123}).to.have.jsonSchema(schema);
-            }).to.throw('expected json to be valid against the specified schema but found following errors: \n' +
+            }).to.throw('expected data to satisfy schema but found following errors: \n' +
                 'data should NOT have additional properties, data should have required property \'alpha\''
             );
         });
@@ -859,13 +859,13 @@ describe('response assertions', function () {
         it('should handle incorrect negated assertions correctly', function () {
             expect(function () {
                 expect({alpha: true}).to.not.have.jsonSchema(schema);
-            }).to.throw('expected json to be invalid against the specified schema');
+            }).to.throw('expected data to not satisfy schema');
         });
 
         it('should override default schema validator options', function () {
             expect(function () {
                 expect({beta: 123, alpha: 123}).to.have.jsonSchema(schema, {allErrors: false});
-            }).to.throw('expected json to be valid against the specified schema but found following errors: \n' +
+            }).to.throw('expected data to satisfy schema but found following errors: \n' +
                 'data.alpha should be boolean'
             );
         });
@@ -881,7 +881,7 @@ describe('response assertions', function () {
 
             expect(function () {
                 expect(response).to.have.jsonSchema(schema, {_parseJSON: false});
-            }).to.throw('expected json to be valid against the specified schema');
+            }).to.throw('expected data to satisfy schema but found following errors');
         });
     });
 });

--- a/test/unit/response.test.js
+++ b/test/unit/response.test.js
@@ -1,11 +1,12 @@
 var _ = require('lodash'),
+    Ajv = require('ajv'),
     chai = require('chai'),
     sdk = require('postman-collection'),
 
     Response = sdk.Response,
     expect = chai.expect;
 
-chai.use(require('../../')(sdk, _));
+chai.use(require('../../')(sdk, _, Ajv));
 
 describe('response assertions', function () {
     describe('.postmanRequestOrResponse', function () {
@@ -825,6 +826,56 @@ describe('response assertions', function () {
             expect(function () {
                 expect(res).to.not.have.responseSize(123);
             }).to.throw('expected response to not have a valid response size but got 45');
+        });
+    });
+
+    describe('.jsonSchema', function () {
+        var schema = {
+            $schema: 'http://json-schema.org/draft-07/schema#',
+            required: ['alpha'],
+            additionalProperties: false,
+            properties: {
+                alpha: { type: 'boolean' },
+                beta: { type: 'boolean' }
+            }
+        };
+
+        it('should assert the data with valid schema correctly', function () {
+            expect({alpha: true}).to.have.jsonSchema(schema);
+        });
+
+        it('should handle negated assertions correctly', function () {
+            expect({alpha: 123}).to.not.have.jsonSchema(schema);
+        });
+
+        it('should handle incorrect assertions correctly', function () {
+            expect(function () {
+                expect({random: 123}).to.have.jsonSchema(schema);
+            }).to.throw('expected json to be valid against the specified schema but found following errors: \n' +
+                'data should NOT have additional properties, data should have required property \'alpha\''
+            );
+        });
+
+        it('should override default schema validator options', function () {
+            expect(function () {
+                expect({beta: 123, alpha: 123}).to.have.jsonSchema(schema, {allErrors: false});
+            }).to.throw('expected json to be valid against the specified schema but found following errors: \n' +
+                'data.alpha should be boolean'
+            );
+        });
+
+        it('should execute `.json()` method by default if exists', function () {
+            var response = new Response({ body: '{"alpha": false}' });
+
+            expect(response).to.have.jsonSchema(schema);
+        });
+
+        it('should not execute `.json()` method if _parseJSON option is false', function () {
+            var response = new Response({ body: '{"alpha": false}' });
+
+            expect(function () {
+                expect(response).to.have.jsonSchema(schema, {_parseJSON: false});
+            }).to.throw('expected json to be valid against the specified schema');
         });
     });
 });

--- a/test/unit/response.test.js
+++ b/test/unit/response.test.js
@@ -844,16 +844,22 @@ describe('response assertions', function () {
             expect({alpha: true}).to.have.jsonSchema(schema);
         });
 
-        it('should handle negated assertions correctly', function () {
-            expect({alpha: 123}).to.not.have.jsonSchema(schema);
-        });
-
         it('should handle incorrect assertions correctly', function () {
             expect(function () {
                 expect({random: 123}).to.have.jsonSchema(schema);
             }).to.throw('expected json to be valid against the specified schema but found following errors: \n' +
                 'data should NOT have additional properties, data should have required property \'alpha\''
             );
+        });
+
+        it('should handle negated assertions correctly', function () {
+            expect({alpha: 123}).to.not.have.jsonSchema(schema);
+        });
+
+        it('should handle incorrect negated assertions correctly', function () {
+            expect(function () {
+                expect({alpha: true}).to.not.have.jsonSchema(schema);
+            }).to.throw('expected json to be invalid against the specified schema');
         });
 
         it('should override default schema validator options', function () {
@@ -864,13 +870,13 @@ describe('response assertions', function () {
             );
         });
 
-        it('should execute `.json()` method by default if exists', function () {
+        it('should auto parse JSON by default if .json() method exists', function () {
             var response = new Response({ body: '{"alpha": false}' });
 
             expect(response).to.have.jsonSchema(schema);
         });
 
-        it('should not execute `.json()` method if _parseJSON option is false', function () {
+        it('should not auto parse JSON if _parseJSON option is false', function () {
             var response = new Response({ body: '{"alpha": false}' });
 
             expect(function () {

--- a/test/unit/response.test.js
+++ b/test/unit/response.test.js
@@ -875,5 +875,25 @@ describe('response assertions', function () {
 
             expect(response).to.have.jsonSchema(schema);
         });
+
+        it('should not auto parse JSON if `json` method exists', function () {
+            var obj = {
+                    alpha: true,
+                    json: function () {
+                        return {
+                            alpha: 123
+                        };
+                    }
+                },
+                schema = {
+                    properties: {
+                        alpha: {
+                            type: 'boolean'
+                        }
+                    }
+                };
+
+            expect(obj).to.have.jsonSchema(schema);
+        });
     });
 });


### PR DESCRIPTION
Added support for:

```javascript
pm.response.to.have.jsonSchema(schema);
pm.response.to.not.have.jsonSchema(schema);

pm.expect(pm.response).to.be.jsonSchema(schema);
pm.expect(pm.response).to.not.be.jsonSchema(schema);

pm.expect('POSTMAN').to.be.jsonSchema({
    "type": "string"
}, {
    // AJV options
    allErrors: true
});
```